### PR TITLE
Optionally alter the RTTY comment with the World Wide Locator square

### DIFF
--- a/config.h
+++ b/config.h
@@ -37,6 +37,8 @@
 
 #define APRS_COMMENT " Hello from the sky!"
 #define RTTY_COMMENT " Hello from the sky!"				// max. 25 characters
+#define RTTY_WWL 1 // Send WWL instead of the comment
+
 #define RTTY_TO_APRS_RATIO 5 //transmit APRS packet with each x RTTY packet
 
 //*************TX Frequencies********************
@@ -73,6 +75,11 @@
 
 //********** Frame Delay in msec**********************
 #define TX_DELAY  5000
+
+// World Wide Locator pairs (precision)
+// max. 6 (12 characters WWL)
+#define PAIR_COUNT 4
+
 #endif
 
 #endif //RS41HUP_CONFIG_H

--- a/locator.c
+++ b/locator.c
@@ -1,0 +1,32 @@
+// Based on HamLib's locator routines
+// OK1TE 2018-10
+
+#include "locator.h"
+#include "config.h"
+
+const static uint8_t loc_char_range[] = { 18, 10, 24, 10, 24, 10 };
+const float precision = 1E+7;
+
+uint8_t longlat2locator(int32_t longitude, int32_t latitude, char locator[]) {
+	if (!locator)
+		return 0;
+
+	for (uint8_t x_or_y = 0; x_or_y < 2; ++x_or_y) {
+		float ordinate = ((x_or_y == 0) ? (longitude / 2) / precision : latitude / precision) + 90;
+		uint32_t divisions = 1;
+
+		for (uint8_t pair = 0; pair < PAIR_COUNT; ++pair) {
+			divisions *= loc_char_range[pair];
+			const float square_size = 180.0 / divisions;
+
+			uint8_t locvalue = (uint8_t) (ordinate / square_size);
+			ordinate -= square_size * locvalue;
+			locvalue += (loc_char_range[pair] == 10) ? '0':'A';
+			locator[pair * 2 + x_or_y] = locvalue;
+		}
+	}
+
+	locator[PAIR_COUNT * 2] = 0;
+
+	return 1;
+}

--- a/locator.h
+++ b/locator.h
@@ -1,0 +1,17 @@
+// Based on HamLib's locator routines
+// OK1TE 2018-10
+#ifndef __LOCATOR_H_
+#define __LOCATOR_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+uint8_t longlat2locator(int32_t longitude, int32_t latitude, char locator[]);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/main.c
+++ b/main.c
@@ -20,6 +20,7 @@
 #include "ublox.h"
 #include "delay.h"
 #include "aprs.h"
+#include "locator.h"
 ///////////////////////////// test mode /////////////
 const unsigned char test = 0; // 0 - normal, 1 - short frame only cunter, height, flag
 char callsign[15] = {CALLSIGN};
@@ -36,6 +37,7 @@ volatile int adc_bottom = 2000;
 volatile char flaga = 0;
 uint16_t CRC_rtty = 0x12ab;  //checksum
 char buf_rtty[200];
+char locator[13];
 
 volatile unsigned char pun = 0;
 volatile unsigned int cun = 10;
@@ -215,6 +217,9 @@ void send_rtty_packet() {
   uint32_t lat_fl = (uint32_t) abs(abs(gpsData.lat_raw) - lat_d * 10000000) / 1000;
   uint8_t lon_d = (uint8_t) abs(gpsData.lon_raw / 10000000);
   uint32_t lon_fl = (uint32_t) abs(abs(gpsData.lon_raw) - lon_d * 10000000) / 1000;
+  if (RTTY_WWL) {
+    longlat2locator(gpsData.lon_raw, gpsData.lat_raw, locator);
+  }
 
   sprintf(buf_rtty, "$$$$%s,%d,%02u:%02u:%02u,%s%d.%04ld,%s%d.%04ld,%ld,%ld,%s,%d,%d.%d,%d,%d,%d,%02x",
 			  callsign,
@@ -224,7 +229,7 @@ void send_rtty_packet() {
               gpsData.lon_raw < 0 ? "-" : "", lon_d, lon_fl,
               (gpsData.alt_raw / 1000),
               gpsData.speed_raw,
-              rtty_comment,
+              RTTY_WWL ? locator : rtty_comment,
               si4032_temperature,
               voltage/100, voltage-voltage/100*100,
               gpsData.sats_raw,


### PR DESCRIPTION
Set the RTTY_WWL in config.h to 1 to send the current WWL (Maidenhead) square in the RTTY packed instead of the static message (comment). Use the PAIR_COUNT to set the desired precision (default value is 4 meaning 8 characters).