### PR TITLE
Fix multiple definition of `ADCVal' linker errors

### DIFF
--- a/init.c
+++ b/init.c
@@ -17,6 +17,7 @@ GPIO_InitTypeDef GPIO_Conf;
 ADC_InitTypeDef ADC_InitStructure;
 DMA_InitTypeDef DMA_InitStructure;
 
+__IO uint16_t ADCVal[2];
 
 #define ADC1_DR_Address    ((uint32_t)0x4001244C)
 #if defined(STM32F10X_CL)

--- a/init.h
+++ b/init.h
@@ -1,4 +1,4 @@
-__IO uint16_t ADCVal[2];
+extern __IO uint16_t ADCVal[2];
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Split declaration/definition of ADCVal so that it's on defined in one C file. ARM GCC 10.2.1 was complaining with:

[100%] Linking CXX executable RS41HUP.elf
/opt/gcc-arm-none-eabi-10-2020-q4-major/bin/../lib/gcc/arm-none-eabi/10.2.1/../../../../arm-none-eabi/bin/ld: CMakeFiles/RS41HUP.elf.dir/main.c.obj:/home/rsaxvc/code/RS41HUP/init.h:1: multiple definition of `ADCVal'; CMakeFiles/RS41HUP.elf.dir/init.c.obj:/home/rsaxvc/code/RS41HUP/init.h:1: first defined here
/opt/gcc-arm-none-eabi-10-2020-q4-major/bin/../lib/gcc/arm-none-eabi/10.2.1/../../../../arm-none-eabi/bin/ld: CMakeFiles/RS41HUP.elf.dir/ublox.c.obj:/home/rsaxvc/code/RS41HUP/init.h:1: multiple definition of `ADCVal'; CMakeFiles/RS41HUP.elf.dir/init.c.obj:/home/rsaxvc/code/RS41HUP/init.h:1: first defined here
/opt/gcc-arm-none-eabi-10-2020-q4-major/bin/../lib/gcc/arm-none-eabi/10.2.1/../../../../arm-none-eabi/bin/ld: CMakeFiles/RS41HUP.elf.dir/QAPRSBase.cpp.obj:/home/rsaxvc/code/RS41HUP/init.h:1: multiple definition of `ADCVal'; CMakeFiles/RS41HUP.elf.dir/init.c.obj:/home/rsaxvc/code/RS41HUP/init.h:1: first defined here
collect2: error: ld returned 1 exit status
